### PR TITLE
Fix flyout direction issue on init/login

### DIFF
--- a/actionBar.lua
+++ b/actionBar.lua
@@ -84,6 +84,7 @@ function ActionBar:New(id)
 	f:UpdateGrid()
 	f:UpdateRightClickUnit()
 	f:SetScript('OnSizeChanged', self.OnSizeChanged)
+	f:UpdateFlyoutDirection()
 
 	active[id] = f
 


### PR DESCRIPTION
Flyouts were not getting direction set properly during initialization,
defaulting to up
