### PR TITLE
Add Gold Tracking in Progress Bar

### DIFF
--- a/Dominos_Progress/Dominos_Progress.toc
+++ b/Dominos_Progress/Dominos_Progress.toc
@@ -1,23 +1,18 @@
-#@retail@
 ## Interface: 90001
-#@end-retail@
-#@non-retail@
-# ## Interface: 11305
-#@end-non-retail@
 ## Title: Dominos Progress
 ## Title-zhCN: |cFF0099FFDominos|r 进度条模块
 ## Notes: Progress bars of all sorts
 ## Notes-zhCN: 各种进度条
 ## Author: Tuller
 ## Dependencies: Dominos
+## OptionalDeps: DataStore
 localization.xml
 config.lua
 main.lua
 progressBar.lua
 xpBar.lua
 reputationBar.lua
-#@retail@
 artifactBar.lua
 azeriteBar.lua
 honorBar.lua
-#@end-retail@
+goldBar.lua

--- a/Dominos_Progress/Dominos_Progress.toc
+++ b/Dominos_Progress/Dominos_Progress.toc
@@ -1,18 +1,24 @@
+#@retail@
 ## Interface: 90001
+#@end-retail@
+#@non-retail@
+# ## Interface: 11305
+#@end-non-retail@
 ## Title: Dominos Progress
 ## Title-zhCN: |cFF0099FFDominos|r 进度条模块
 ## Notes: Progress bars of all sorts
 ## Notes-zhCN: 各种进度条
 ## Author: Tuller
 ## Dependencies: Dominos
-## OptionalDeps: DataStore
 localization.xml
 config.lua
 main.lua
 progressBar.lua
 xpBar.lua
 reputationBar.lua
+#@retail@
 artifactBar.lua
 azeriteBar.lua
 honorBar.lua
 goldBar.lua
+#@end-retail@

--- a/Dominos_Progress/config.lua
+++ b/Dominos_Progress/config.lua
@@ -42,12 +42,15 @@ function Config:GetDefaults()
 		profile = {
 			one_bar = true,
 			skip_inactive_modes = false,
+                gold_goal = 0,
 			colors = {
 				xp = {0.58, 0, 0.55, 1},
 				xp_bonus = {0, 0.39, 0.88},
 				honor = {1.0, 0.24, 0, 1},
 				artifact = {1, 0.75, 0.45, 0.81},
-				azerite = {0.601, 0.8, 0.901, 1}
+				azerite = {0.601, 0.8, 0.901, 1},
+                     gold = {1, .8431, 0, 1},
+                     gold_realm = {1, .9451, .7294, 1}
 			}
 		},
 
@@ -96,6 +99,14 @@ end
 
 function Config:SkipInactiveModes()
 	return self.db.profile.skip_inactive_modes
+end
+
+function Config:GoldGoal()
+     return self.db.profile.gold_goal
+end
+
+function Config:SetGoldGoal(value)
+     self.db.profile.gold_goal = value or 0
 end
 
 function Config:SetColor(key, ...)

--- a/Dominos_Progress/goldBar.lua
+++ b/Dominos_Progress/goldBar.lua
@@ -1,0 +1,42 @@
+local _, Addon = ...
+local Dominos = _G.Dominos
+local GoldBar = Dominos:CreateClass("Frame", Addon.ProgressBar)
+
+
+function GoldBar:Init()
+	self:Update()
+	self:SetColor(Addon.Config:GetColor("gold"))
+	self:SetBonusColor(Addon.Config:GetColor("gold_realm"))
+end
+
+function GoldBar:Update()
+	local gold = GetMoney("player")
+	local max = Addon.Config:GoldGoal()
+
+	if DataStore then
+	    realm = 0
+         for _, c in pairs(DataStore:GetCharacters()) do
+             realm = realm + DataStore:GetMoney(c)
+         end
+         realm = realm - gold
+	else
+	    realm = 0
+	end
+
+     if max == 0 then
+         max = (gold + realm) / 10000
+     end
+
+	self:SetValues(gold, max*10000, realm)
+	self:UpdateText(_G.MONEY, gold/10000, max, realm/10000)
+end
+
+function GoldBar:IsModeActive()
+     local goal = Addon.Config:GoldGoal()
+	return goal and goal > 0
+end
+
+-- register this as a possible progress bar mode
+Addon.progressBarModes = Addon.progressBarModes or {}
+Addon.progressBarModes["gold"] = GoldBar
+Addon.ExperienceBar = GoldBar

--- a/Dominos_Progress/goldBar.lua
+++ b/Dominos_Progress/goldBar.lua
@@ -39,4 +39,4 @@ end
 -- register this as a possible progress bar mode
 Addon.progressBarModes = Addon.progressBarModes or {}
 Addon.progressBarModes["gold"] = GoldBar
-Addon.ExperienceBar = GoldBar
+Addon.GoldBar = GoldBar

--- a/Dominos_Progress/localization/localization.lua
+++ b/Dominos_Progress/localization/localization.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 	Localization.lua
 		Translations for Dominos XP (English - Default Version)
 --]]
@@ -28,7 +28,10 @@ L.Color_honor = 'Honor Color'
 L.Color_honor_bonus = 'Bonus Honor Color'
 L.Color_artifact = 'Artifact Color'
 L.Color_azerite = 'Azerite Color'
+L.Color_gold = 'Gold Color'
+L.Color_gold_realm = 'Gold Realm Color'
 
 L.Paragon = 'Paragon'
 L.Azerite = 'Azerite Power'
 L.SkipInactiveModes = "Skip Inactive Modes"
+L.GoldGoal = "Gold Goal Amount"

--- a/Dominos_Progress/main.lua
+++ b/Dominos_Progress/main.lua
@@ -119,7 +119,7 @@ function ProgressBarModule:HONOR_XP_UPDATE()
 	self:UpdateAllBars()
 end
 
-function ProgressBarModule:PLAYER_MONEY_UPDATE()
+function ProgressBarModule:PLAYER_MONEY()
      self:UpdateAllBars()
 end
 

--- a/Dominos_Progress/main.lua
+++ b/Dominos_Progress/main.lua
@@ -36,6 +36,11 @@ function ProgressBarModule:OnEnable()
 		self:RegisterEvent("AZERITE_ITEM_EXPERIENCE_CHANGED")
 	end
 
+     -- gold events
+     if Addon.GoldBar then
+           self:RegisterEvent("PLAYER_MONEY")
+     end
+
 	-- addon and library callbacks
 	Dominos.RegisterCallback(self, "OPTIONS_MENU_LOADING")
 	LibStub("LibSharedMedia-3.0").RegisterCallback(self, 'LibSharedMedia_Registered')
@@ -48,11 +53,11 @@ function ProgressBarModule:Load()
 		}
 	elseif Addon.Config:OneBarMode() then
 		self.bars = {
-			Addon.ProgressBar:New("exp", {"xp", "reputation", "honor", "artifact", "azerite"})
+			Addon.ProgressBar:New("exp", {"xp", "reputation", "honor", "artifact", "azerite", "gold"})
 		}
 	else
 		self.bars = {
-			Addon.ProgressBar:New("exp", {"xp", "reputation", "honor"}),
+			Addon.ProgressBar:New("exp", {"xp", "reputation", "honor", "gold"}),
 			Addon.ProgressBar:New("artifact", {"azerite", "artifact"})
 		}
 	end
@@ -114,6 +119,10 @@ function ProgressBarModule:HONOR_XP_UPDATE()
 	self:UpdateAllBars()
 end
 
+function ProgressBarModule:PLAYER_MONEY_UPDATE()
+     self:UpdateAllBars()
+end
+
 function ProgressBarModule:LibSharedMedia_Registered()
 	self:UpdateAllBars()
 end
@@ -157,10 +166,26 @@ function ProgressBarModule:AddOptionsPanel()
 				end		
 			},			
 
+                range(L.GoldGoal) {
+                     min = 0,
+                     max = 10000000,
+                     softMin = 0,
+                     softMax = 100000,
+                     step = 100,
+                     bigStep = 1000,
+                     get = function()
+                           return Addon.Config:GoldGoal()
+                     end,
+                     set = function(_, value)
+                           Addon.Config:SetGoldGoal(value)
+                           self:UpdateAllBars()
+                     end,
+                },
+
 			h(COLORS)
 		}		
 
-		for _, key in ipairs{ "xp", "xp_bonus", "honor", "artifact", "azerite" } do
+		for _, key in ipairs{ "xp", "xp_bonus", "honor", "artifact", "azerite", "gold", "gold_realm" } do
 			tinsert(options, color(L["Color_" .. key]) {
 				hasAlpha = true,
 	


### PR DESCRIPTION
I had some time to implement the enhancement request I made in #495 

![image](https://user-images.githubusercontent.com/2967926/98482500-e17dd880-21cf-11eb-93a3-17849f184c57.png)

![image](https://user-images.githubusercontent.com/2967926/98483174-36235280-21d4-11eb-92e2-b99ffec5ec50.png)

It should be fully working, though only having English localization.

If the goal value is set to 0 it will treat the bar as inactive. If `DataStore` from Altoholic and similar addons is present it will display realm gold as a secondary progress bar (eg. like xp and rested xp do).


resolves #495 