### PR TITLE
Remove castbar fade on cast start

### DIFF
--- a/Dominos_Cast/DominosTimerBarTemplate.xml
+++ b/Dominos_Cast/DominosTimerBarTemplate.xml
@@ -7,7 +7,7 @@
     <Frame name="DominosTimerBarTemplate" setAllPoints="true" alpha="0" virtual="true" mixin="DominosTimerBarMixin">
         <Animations>
             <AnimationGroup parentKey="fadeIn" setToFinalAlpha="true">
-                <Alpha duration="0.3" fromAlpha="0" toAlpha="1"/>
+                <Alpha duration="0.3" fromAlpha="1" toAlpha="1"/>
             </AnimationGroup>
             <AnimationGroup parentKey="fadeOut" setToFinalAlpha="true">
                 <Alpha duration="0.3" fromAlpha="1" toAlpha="0"/>


### PR DESCRIPTION
The opacity animation on castbar show causes a delay in perception of the cast start, which is a bit annoying.
Also on issue #595.

I'm not very knowledgeable on WoW UI so I just changed the animation parameters here.

Gave a quick look on actually removing the animation but it seemed more complicated than what I'd like. Open to suggestions.