### PR TITLE
match blizzard's button order

### DIFF
--- a/Dominos/bars/menuBar.lua
+++ b/Dominos/bars/menuBar.lua
@@ -19,11 +19,11 @@ if Addon:IsBuild('retail') then
         "QuestLogMicroButton",
         "GuildMicroButton",
         "LFDMicroButton",
-        "EJMicroButton",
         "CollectionsMicroButton",
-        "MainMenuMicroButton",
+        "EJMicroButton",
+        "StoreMicroButton",
         -- "HelpMicroButton",
-        "StoreMicroButton"
+        "MainMenuMicroButton"
     }
 else
     MICRO_BUTTONS = _G.MICRO_BUTTONS


### PR DESCRIPTION
Minor change to the micromenu's button order, now matches blizzard's default.