### PR TITLE
Fix capitalization of `showGridButton.Text`.

### DIFF
--- a/Dominos_Config/overlay/help.lua
+++ b/Dominos_Config/overlay/help.lua
@@ -66,7 +66,7 @@ function HelpDialog:OnLoad(owner)
 
     local showGridButton = _G.CreateFrame('CheckButton', nil, self, "UICheckButtonTemplate")
 
-    showGridButton.text:SetText(L.ShowAlignmentGrid)
+    showGridButton.Text:SetText(L.ShowAlignmentGrid)
     showGridButton:SetChecked(Addon:GetParent():GetAlignmentGridEnabled())
     showGridButton:SetScript('OnClick', function(button) self:OnShowGridButtonClicked(button) end)
     showGridButton:SetPoint('BOTTOMLEFT', 14, 10)


### PR DESCRIPTION
On the WOTLK PTR, without this change, an error occurs:

```
1x Dominos_Config/overlay/help.lua:69: attempt to index field 'text' (a nil value)
[string "@Dominos_Config/overlay/help.lua"]:69: in function `OnLoad'
[string "@Dominos_Config/overlay/ui.lua"]:68: in function <Dominos_Config/overlay/ui.lua:22>
[string "=[C]"]: ?
```