### PR TITLE
Fix action offsets so bars keep unique slots

### DIFF
--- a/Dominos/bars/actionBar/bar.lua
+++ b/Dominos/bars/actionBar/bar.lua
@@ -152,7 +152,13 @@ function ActionBar:ReleaseButton(button)
 end
 
 function ActionBar:OnAttachButton(button)
-    button:SetAttribute("action", button:GetAttribute("index") + (self:GetAttribute("actionOffset") or 0))
+    local offset = self:GetAttribute("actionOffset")
+    if offset == nil then
+        offset = (self.id - 1) * self:MaxLength()
+        self:SetAttribute("actionOffset", offset)
+    end
+
+    button:SetAttribute("action", button:GetAttribute("index") + offset)
     button:SetFlyoutDirectionInsecure(self:GetFlyoutDirection())
 
     for _, prop in pairs(self.ButtonProps) do


### PR DESCRIPTION
## Summary
- seed actionOffset on button attach when the state driver hasn\'t produced one yet
- prevents action bar 1 slots from mirroring across bars 2-14 and resolves the midnight 12.0 beta regression where extra bars vanish due to nil offsets

## Testing
- not run (environment-only change)