### PR TITLE
(TBC) fix enabling of override UI, resolves #1008

### DIFF
--- a/Dominos/Dominos.lua
+++ b/Dominos/Dominos.lua
@@ -276,7 +276,7 @@ function Addon:GetDatabaseDefaults()
             showTooltipsCombat = true,
             showSpellGlows = true,
             showSpellAnimations = true,
-            useOverrideUI = not self:IsBuild('vanilla', 'tbc'),
+            useOverrideUI = not self:IsBuild('vanilla'),
 
             ab = {
                 count = self.ACTION_BUTTON_COUNT / NUM_ACTIONBAR_BUTTONS,

--- a/Dominos/core/overrideController.lua
+++ b/Dominos/core/overrideController.lua
@@ -1,5 +1,5 @@
 local _, Addon = ...
-if not Addon:IsBuild('retail', 'mists', 'cata', 'wrath') then
+if not Addon:IsBuild('retail', 'mists', 'cata', 'wrath', 'tbc') then
 	return
 end
 


### PR DESCRIPTION
Fixes #1008 

### Changes
- Remove skip of 'tbc' in default db profile's overrideUI setting
- Add 'tbc' to whitelisted builds in the overrideController guard

Consistent with the main addon's .toc-file which already allows loading of the overrideController for tbc.

### Validation
1. Open dominos config with /dominos
2. Check 'Use Blizzard Override Action Bar'
3. Select any visible bar for the 'Override Bar' dropdown
4. Trigger the override UI, e.g. by using item 'Steam Tonk Controller', casting 'Eyes of the Beast' on a hunter, or similar.
5. The bar that was selected in step 3 shows the bar that overrides (e.g. tonk/pet)

### New/remaining issues
After casting 'Eyes of the Beast', the pet bar is not restored as it was before. Specifically, the autocast status of abilities no longer shows, see print screens [before](https://i.gyazo.com/bdd51509d8fab58e7d3267dee763c87b.png) and [after](https://i.gyazo.com/48aab301f0dce9035264f14d8eec953a.png) for reference.  _This also prevents toggling of autocast status by right-clicking the buttons._

Note that if pet is dismissed and called/re-summoned the autocast buttons are restored to show and behave as expected again.