### PR TITLE
feat: implement button flashing on keybind press

### DIFF
--- a/Dominos/Dominos.lua
+++ b/Dominos/Dominos.lua
@@ -276,6 +276,7 @@ function Addon:GetDatabaseDefaults()
             showTooltipsCombat = true,
             showSpellGlows = true,
             showSpellAnimations = true,
+            showButtonFlash = false,
             useOverrideUI = not self:IsBuild('vanilla'),
 
             ab = {
@@ -697,6 +698,18 @@ end
 
 function Addon:ShowingSpellAnimations()
     return self.db.profile.showSpellAnimations
+end
+
+-- button press flash
+function Addon:SetShowButtonFlash(enable)
+    enable = enable and true
+
+    self.db.profile.showButtonFlash = enable
+    self.callbacks:Fire("SHOW_BUTTON_FLASH_CHANGED", enable)
+end
+
+function Addon:ShowingButtonFlash()
+    return self.db.profile.showButtonFlash
 end
 
 -- spell overlay glows

--- a/Dominos/Dominos.toc
+++ b/Dominos/Dominos.toc
@@ -21,6 +21,7 @@ core\frame.lua
 core\buttonBar.lua
 core\bindableButton.lua
 core\fadeManager.lua
+core\buttonFlash.lua
 core\overrideController.lua [AllowLoadGameType mainline, mists, cata, wrath, tbc]
 core\tooltipController.lua
 core\blizzardHider.lua [AllowLoadGameType mainline, mists, tbc, vanilla]

--- a/Dominos/bars/actionBar/bar.lua
+++ b/Dominos/bars/actionBar/bar.lua
@@ -159,6 +159,7 @@ function ActionBar:OnAttachButton(button)
         button['SetShow' .. prop](button, self['Showing' .. prop](self))
     end
 
+    button:SetShowButtonFlash(Addon:ShowingButtonFlash())
     button:SetShowCooldowns(self:GetAlpha() > 0)
     button:SetAttributeNoHandler("statehidden", (button:GetAttribute("index") > self:NumButtons()) or nil)
     button:UpdateShown()

--- a/Dominos/bars/actionBar/button.classic.lua
+++ b/Dominos/bars/actionBar/button.classic.lua
@@ -51,6 +51,7 @@ function ActionButton:OnCreate(id)
 
     -- bindings setup
     Addon.BindableButton:AddQuickBindingSupport(self)
+    Addon.ButtonFlash:Add(self)
 end
 
 function ActionButton:UpdateShown()
@@ -136,6 +137,10 @@ end
 
 function ActionButton:SetShowMacroText(show)
     self.Name:SetShown(show and true)
+end
+
+function ActionButton:SetShowButtonFlash(show)
+    Addon.ButtonFlash:SetEnabled(self, show)
 end
 
 if ActionButton_UpdateHotkeys then

--- a/Dominos/bars/actionBar/button.lua
+++ b/Dominos/bars/actionBar/button.lua
@@ -101,6 +101,7 @@ function ActionButton:OnCreate(id)
 
     -- ...and the rest
     Addon.BindableButton:AddQuickBindingSupport(self)
+    Addon.ButtonFlash:Add(self)
 
     if Addon.SpellFlyout then
         Addon.SpellFlyout:Register(self)
@@ -213,6 +214,10 @@ end
 
 function ActionButton:SetShowMacroText(show)
     self.Name:SetShown(show and true)
+end
+
+function ActionButton:SetShowButtonFlash(show)
+    Addon.ButtonFlash:SetEnabled(self, show)
 end
 
 -- exports

--- a/Dominos/bars/actionBar/buttons.classic.lua
+++ b/Dominos/bars/actionBar/buttons.classic.lua
@@ -37,6 +37,8 @@ function ActionButtons:Initialize()
     self:RegisterEvent("CVAR_UPDATE")
     self:RegisterEvent("PLAYER_REGEN_ENABLED")
 
+    Addon.RegisterCallback(self, "SHOW_BUTTON_FLASH_CHANGED")
+
     -- watch for keybound show/hide
     local keybound = LibStub("LibKeyBound-1.0", true)
     if keybound then
@@ -68,6 +70,10 @@ end
 
 function ActionButtons:LIBKEYBOUND_DISABLED()
     self:SetShowGrid(false, self.ShowGridReasons.KEYBOUND_EVENT)
+end
+
+function ActionButtons:SHOW_BUTTON_FLASH_CHANGED(_, show)
+    self:ForAll("SetShowButtonFlash", show)
 end
 
 function ActionButtons:TrySetAttribute(key, value)

--- a/Dominos/bars/actionBar/buttons.lua
+++ b/Dominos/bars/actionBar/buttons.lua
@@ -46,6 +46,7 @@ function ActionButtons:Initialize()
     Addon.RegisterCallback(self, "LAYOUT_LOADED")
     Addon.RegisterCallback(self, "SHOW_SPELL_ANIMATIONS_CHANGED")
     Addon.RegisterCallback(self, "SHOW_SPELL_GLOWS_CHANGED")
+    Addon.RegisterCallback(self, "SHOW_BUTTON_FLASH_CHANGED")
 
     -- library callbacks
     local keybound = LibStub("LibKeyBound-1.0", true)
@@ -204,9 +205,14 @@ function ActionButtons:SHOW_SPELL_GLOWS_CHANGED(_, show)
     self:SetShowSpellGlows(show)
 end
 
+function ActionButtons:SHOW_BUTTON_FLASH_CHANGED(_, show)
+    self:SetShowButtonFlash(show)
+end
+
 function ActionButtons:LAYOUT_LOADED()
     self:SetShowSpellGlows(Addon:ShowingSpellGlows())
     self:SetShowSpellAnimations(Addon:ShowingSpellAnimations())
+    self:SetShowButtonFlash(Addon:ShowingButtonFlash())
 end
 
 function ActionButtons:OnActionChanged(buttonName, action)
@@ -442,6 +448,10 @@ end
 
 function ActionButtons:SetShowGrid(show, reason, force)
     self:ForAll("SetShowGridInsecure", show, reason, force)
+end
+
+function ActionButtons:SetShowButtonFlash(enable)
+    self:ForAll("SetShowButtonFlash", enable)
 end
 
 function ActionButtons:SetShowSpellGlows(enable)

--- a/Dominos/core/buttonFlash.lua
+++ b/Dominos/core/buttonFlash.lua
@@ -1,0 +1,91 @@
+local _, Addon = ...
+
+local ButtonFlash = {}
+
+local function createAnimation(button)
+    local frame = CreateFrame('Frame', nil, UIParent)
+    frame:SetFrameStrata('TOOLTIP')
+
+    local texture = frame:CreateTexture()
+    texture:SetTexture([[Interface\Cooldown\star4]])
+    texture:SetAlpha(0)
+    texture:SetAllPoints(frame)
+    texture:SetBlendMode('ADD')
+    texture:SetDrawLayer('OVERLAY', 7)
+
+    local animation = texture:CreateAnimationGroup()
+
+    local alpha = animation:CreateAnimation('Alpha')
+    alpha:SetFromAlpha(0)
+    alpha:SetToAlpha(1)
+    alpha:SetDuration(0)
+    alpha:SetOrder(1)
+
+    local scale1 = animation:CreateAnimation('Scale')
+    scale1:SetScale(1.5, 1.5)
+    scale1:SetDuration(0)
+    scale1:SetOrder(1)
+
+    local scale2 = animation:CreateAnimation('Scale')
+    scale2:SetScale(0, 0)
+    scale2:SetDuration(0.3)
+    scale2:SetOrder(2)
+
+    local rotation = animation:CreateAnimation('Rotation')
+    rotation:SetDegrees(90)
+    rotation:SetDuration(0.3)
+    rotation:SetOrder(2)
+
+    frame.texture = texture
+    frame.animation = animation
+    frame:Hide()
+
+    return frame
+end
+
+function ButtonFlash:Add(button)
+    if button.buttonFlash then
+        return
+    end
+
+    button.buttonFlash = createAnimation(button)
+
+    if button.SetButtonStateBase then
+        hooksecurefunc(button, 'SetButtonStateBase', function(self, state)
+            if state == 'PUSHED' then
+                ButtonFlash:Play(self)
+            end
+        end)
+    end
+end
+
+function ButtonFlash:SetEnabled(button, enabled)
+    local frame = button.buttonFlash
+    if not frame then
+        return
+    end
+
+    frame.enabled = enabled and true or nil
+    if not frame.enabled then
+        frame.animation:Stop()
+        frame.texture:SetAlpha(0)
+        frame:Hide()
+    end
+end
+
+function ButtonFlash:Play(button)
+    local frame = button.buttonFlash
+    if not frame or not frame.enabled or not button:IsVisible() then
+        return
+    end
+
+    frame:ClearAllPoints()
+    frame:SetAllPoints(button)
+    frame:SetFrameLevel(button:GetFrameLevel() + 10)
+    frame:Show()
+    frame.texture:SetAlpha(0)
+    frame.animation:Stop()
+    frame.animation:Play()
+end
+
+Addon.ButtonFlash = ButtonFlash


### PR DESCRIPTION
Hi guys,

I wanted to contribute a little bit with the help of AI. 

This PR adds one checkbox in the options for flashing keys on keypress and appropiate keyflashing animation based on old SnowflashKeyPress addon.

This is how it looks now:
https://youtu.be/0Hllr4em_H4

Tested under TBC Anniversary 20506. I did not test it on retail though.